### PR TITLE
Make create_tower.py Python 3 compatible

### DIFF
--- a/scripts/create_tower.py
+++ b/scripts/create_tower.py
@@ -246,15 +246,16 @@ if args.verbose:
 	for index in range(0, len(room_names)):
 		rooms.append([room_diffs[index], room_names[index], room_ids[index], str(room_authors[index])])
 	rooms.sort(key = lambda r: int(r[0]))
+	leftpad = lambda val, length: "%s%s" % (" " * (length - len(val)), val)
 	for index in range(0, len(rooms)):
 		room = rooms[index]
 		num = str(index + 1)
 		print("| %s | %s | %s | %s | %s |" % (
-			" " * (3 - len(num)) + num,
-			" " * (4 - len(room[0])) + room[0],
-			room[1] + " " * (24 - len(room[1])),
+			leftpad(num, 3),
+			leftpad(room[0], 4),
+			leftpad(room[1], 24),
 			room[2],
-			room[3] + " " * (32 - len(room[3]))
+			leftpad(room[3], 32)
 		))
 	print("---------------------------------------------------------------------------------")
 

--- a/scripts/create_tower.py
+++ b/scripts/create_tower.py
@@ -17,12 +17,12 @@ import subprocess
 def copy_room(room_dir, tower_dir):
 	# get room name
 	room_name = room_dir.split(".")[0][4:]
-	print "copying room " + room_name + " ..."
+	print("copying room " + room_name + " ...")
 	
 	# check against double room names
 	if room_name in room_names:
-		print "ERROR: room name (" + room_name + ") already used."
-		print "WARNING: room " + room_name + " will not be included."
+		print("ERROR: room name (" + room_name + ") already used.")
+		print("WARNING: room " + room_name + " will not be included.")
 
 	# copy room object
 	room_obj_dir = tower_dir + "/Room" + room_name + ".ocd"
@@ -59,7 +59,7 @@ def copy_room(room_dir, tower_dir):
 	if not check_room(room_name, tower_dir):
 		shutil.rmtree(room_obj_dir)
 		shutil.rmtree(sect_dir)
-		print "WARNING: room " + room_name + " will not be included."
+		print("WARNING: room " + room_name + " will not be included.")
 	# add to list of room names
 	else:
 		room_names.append(room_name)
@@ -75,7 +75,7 @@ def check_room(room_name, tower_dir):
 		# check room object id
 		for line in lines:
 			if re.match("id=*", line) and not re.match("id=Room" + room_name, line):
-				print "ERROR: Room control object DefCore.txt has wrong id, found " + line.replace("\n", "") + ", expected id=Room" + room_name + "."
+				print("ERROR: Room control object DefCore.txt has wrong id, found " + line.replace("\n", "") + ", expected id=Room" + room_name + ".")
 				room_ok = False
 
 	# open room control object script
@@ -84,22 +84,22 @@ def check_room(room_name, tower_dir):
 		for line in lines:
 			# check room section
 			if re.match("public func GetRoomSection()*", line) and not re.search(room_name, line):
-				print "ERROR: Room control object Script.c has wrong section, found " + line.replace("\n", "") + ", expected public func GetRoomSection() { return \"" + room_name + "\"; }."
+				print("ERROR: Room control object Script.c has wrong section, found " + line.replace("\n", "") + ", expected public func GetRoomSection() { return \"" + room_name + "\"; }.")
 				room_ok = False
 			# room id (either double or excluded)
 			if re.match("public func GetRoomID()*", line):
 				room_id = re.search("\"[a-zA-Z]+\"", line).group(0).replace("\"", "")
 				if room_id in room_ids:
-					print "ERROR: Room control object Script.c has duplicate ID, found " + line.replace("\n", "") + ", expected public func GetRoomID() { return \"??\"; }."
+					print("ERROR: Room control object Script.c has duplicate ID, found " + line.replace("\n", "") + ", expected public func GetRoomID() { return \"??\"; }.")
 					room_ok = False
 				elif isinstance(args.exclude, list) and room_id in args.exclude:
-					print "EXCLUDE: Room with id = " + room_id + " will be excluded as requested."
+					print("EXCLUDE: Room with id = " + room_id + " will be excluded as requested.")
 					room_ok = False
 			# difficulty
 			if re.match("public func GetRoomDifficulty()*", line):
 				room_diff = re.search("return [0-9]+;", line).group(0).replace(";", "")[7:]
 				if room_diff in room_diffs:
-					print "ERROR: Room control object Script.c has duplicate difficulty, found " + line.replace("\n", "") + ", expected public func GetRoomDifficulty() { return \"?\"; }."
+					print("ERROR: Room control object Script.c has duplicate difficulty, found " + line.replace("\n", "") + ", expected public func GetRoomDifficulty() { return \"?\"; }.")
 					room_ok = False
 			# room author(s)
 			if re.match("public func GetRoomAuthor()*", line):
@@ -111,9 +111,9 @@ def check_room(room_name, tower_dir):
 		room_diffs.append(room_diff)
 		room_authors.append(room_author)
 	
-	# print room settings
+	# print(room settings)
 	if args.verbose and room_ok:
-		print "room properties: id = " + room_id + ", difficulty = " + room_diff
+		print("room properties: id = " + room_id + ", difficulty = " + room_diff)
 
 	# return whether the room is ok
 	return room_ok
@@ -140,7 +140,7 @@ room_authors = []
 
 # create tower directory based on version name
 if not os.path.isfile("Version.txt"):
-	print "ERROR: Version.txt file not found, be sure to run the script from the tower path."
+	print("ERROR: Version.txt file not found, be sure to run the script from the tower path.")
 	sys.exit(0)
 with open("Version.txt", "r") as content_file:
     version = content_file.read()
@@ -153,11 +153,11 @@ elif os.path.exists(tower_dir):
 os.makedirs(tower_dir)
 
 # log which version is created
-print "creating tower scenario version " + version
-print "==========================================="
+print("creating tower scenario version " + version)
+print("===========================================")
 
 # copy main scenario files into the new directory
-print "copying main scenario ..."
+print("copying main scenario ...")
 shutil.copy("Version.txt", tower_dir)
 shutil.copy("Authors.txt", tower_dir)
 shutil.copy("Title.txt", tower_dir)
@@ -177,23 +177,23 @@ shutil.copy("Title.jpg", tower_dir)
 shutil.copy("Loader1.png", tower_dir)
 
 # copy sound files into the new directory
-print "copying sound files ..."
+print("copying sound files ...")
 shutil.copytree("Sound.ocg", tower_dir + "/Sound.ocg")
 
 # copy material files into the new directory
-print "copying material files ..."
+print("copying material files ...")
 shutil.copytree("Material.ocg", tower_dir + "/Material.ocg")
 
 # copy tower objects into the new directory
-print "copying tower objects ..."
+print("copying tower objects ...")
 shutil.copytree("TowerObjects.ocd", tower_dir + "/TowerObjects.ocd")
 
 # copy empty scenario section into the new directory
-print "copying empty scenario section ..."
+print("copying empty scenario section ...")
 shutil.copytree("SectEmpty.ocg", tower_dir + "/SectEmpty.ocg")
 
 # loop over all rooms and copy sections and room object
-print "==========================================="
+print("===========================================")
 for room_dir in os.listdir("."):
 	if fnmatch.fnmatch(room_dir, "Room*.ocs") and not fnmatch.fnmatch(room_dir, "RoomTemplate.ocs"):
 		copy_room(room_dir, tower_dir)
@@ -214,17 +214,17 @@ strtbl_de.close()
 
 # pack the scenario folder if required
 if args.pack:
-	print "==========================================="
-	print "packing scenario folder ..."
+	print("===========================================")
+	print("packing scenario folder ...")
 	try:
 		subprocess.call(["c4group", tower_dir, "-p"])
 	except OSError as e:
-		print "ERROR: failed to run c4group."
+		print("ERROR: failed to run c4group.")
 
 # create template room
 if args.template:
-	print "==========================================="
-	print "create room template ..."
+	print("===========================================")
+	print("create room template ...")
 	template_dir = "../Template.ocg"
 	if not os.path.isdir(template_dir):
 		os.makedirs(template_dir)
@@ -235,12 +235,12 @@ if args.template:
 
 # if verbose option create the list of rooms sorted according to difficulty
 if args.verbose:
-	print "==========================================="
-	print "list of rooms ..."
-	print "==========================================="
-	print "---------------------------------------------------------------------------------"
-	print "|  #  | Diff | Room name                | ID | Author(s)                        |"
-	print "---------------------------------------------------------------------------------"
+	print("===========================================")
+	print("list of rooms ...")
+	print("===========================================")
+	print("---------------------------------------------------------------------------------")
+	print("|  #  | Diff | Room name                | ID | Author(s)                        |")
+	print("---------------------------------------------------------------------------------")
 	# create a list of rooms
 	rooms = []
 	for index in range(0, len(room_names)):
@@ -249,11 +249,11 @@ if args.verbose:
 	for index in range(0, len(rooms)):
 		room = rooms[index]
 		num = str(index + 1)
-		print "| " + " " * (3 - len(num)) + num + " | " + " " * (4 - len(room[0])) + room[0] + " | " + room[1] + " " * (24 - len(room[1])) + " | " + room[2] + " | " + room[3] + " " * (32 - len(room[3])) + " |"
-	print "---------------------------------------------------------------------------------"
+		print("| " + " " * (3 - len(num)) + num + " | " + " " * (4 - len(room[0])) + room[0] + " | " + room[1] + " " * (24 - len(room[1])) + " | " + room[2] + " | " + room[3] + " " * (32 - len(room[3])) + " |")
+	print("---------------------------------------------------------------------------------")
 
 # finished
-print "==========================================="
-print "finished"
+print("===========================================")
+print("finished")
 
 

--- a/scripts/create_tower.py
+++ b/scripts/create_tower.py
@@ -25,32 +25,32 @@ def copy_room(room_dir, tower_dir):
 		print("WARNING: room " + room_name + " will not be included.")
 
 	# copy room object
-	room_obj_dir = tower_dir + "/Room" + room_name + ".ocd"
+	room_obj_dir = os.path.join(tower_dir, "Room" + room_name + ".ocd")
 	for object_dir in os.listdir(room_dir):
 		if fnmatch.fnmatch(object_dir, "Room*.ocd"):
-			shutil.copytree(room_dir + "/" + object_dir, room_obj_dir)
+			shutil.copytree(os.path.join(room_dir, object_dir), room_obj_dir)
 
 	# copy room map and stored objects
-	sect_dir = tower_dir + "/Sect" + room_name + ".ocg"
+	sect_dir = os.path.join(tower_dir, "Sect" + room_name + ".ocg")
 	os.makedirs(sect_dir)
 	for sect_file in os.listdir(room_dir):
 		# copy scenario settings
 		if fnmatch.fnmatch(sect_file, "Scenario.txt"):
-			shutil.copy(room_dir + "/" + sect_file, sect_dir)
+			shutil.copy(os.path.join(room_dir, sect_file), sect_dir)
 			# modify scenario.txt to only have the needed settings
-			with open(sect_dir + "/" + sect_file, "r") as f:
+			with open(os.path.join(sect_dir, sect_file), "r") as f:
 				lines = f.readlines()
-			with open(sect_dir + "/" + sect_file, "w") as f:
+			with open(os.path.join(sect_dir, sect_file), "w") as f:
 				for line in lines:
 					if not re.match("Icon=*", line) and not re.match("Title=*", line) and not re.match("Version=*", line) and not re.match("Origin=*", line):
 						f.write(line)
 		# copy scenario map, objects and string tables
 		if fnmatch.fnmatch(sect_file, "Map*.bmp") or fnmatch.fnmatch(sect_file, "Objects.c") or fnmatch.fnmatch(sect_file, "StringTbl*.txt"):
-			shutil.copy(room_dir + "/" + sect_file, sect_dir)
+			shutil.copy(os.path.join(room_dir, sect_file), sect_dir)
 		# append map script to room control script object.
 		if fnmatch.fnmatch(sect_file, "Map.c"):
-			with open(room_dir + "/" + sect_file, "r") as map_file:
-				with open(tower_dir + "/Room" + room_name + ".ocd/Script.c", "a") as script_file:
+			with open(os.path.join(room_dir, sect_file), "r") as map_file:
+				with open(os.path.join(tower_dir, "Room" + room_name + ".ocd", "Script.c"), "a") as script_file:
 					for line in map_file.readlines():
 						if not re.match("#include *", line):
 							script_file.write(line)	
@@ -70,7 +70,7 @@ def check_room(room_name, tower_dir):
 	# to store whether room is ok
 	room_ok = True
 	# open room control object defcore
-	with open(tower_dir + "/Room" + room_name + ".ocd/DefCore.txt", "r") as f:
+	with open(os.path.join(tower_dir, "Room" + room_name + ".ocd", "DefCore.txt"), "r") as f:
 		lines = f.readlines()
 		# check room object id
 		for line in lines:
@@ -79,7 +79,7 @@ def check_room(room_name, tower_dir):
 				room_ok = False
 
 	# open room control object script
-	with open(tower_dir + "/Room" + room_name + ".ocd/Script.c", "r") as f:
+	with open(os.path.join(tower_dir, "Room" + room_name + ".ocd", "Script.c"), "r") as f:
 		lines = f.readlines()
 		for line in lines:
 			# check room section
@@ -144,7 +144,7 @@ if not os.path.isfile("Version.txt"):
 	sys.exit(0)
 with open("Version.txt", "r") as content_file:
     version = content_file.read()
-tower_dir = "../OCTowerV" + version + ".ocs"
+tower_dir = os.path.join("..", "OCTowerV" + version + ".ocs")
 ## TODO: query replacing existing directory
 if os.path.isfile(tower_dir):
 	os.remove(tower_dir)
@@ -178,19 +178,19 @@ shutil.copy("Loader1.png", tower_dir)
 
 # copy sound files into the new directory
 print("copying sound files ...")
-shutil.copytree("Sound.ocg", tower_dir + "/Sound.ocg")
+shutil.copytree("Sound.ocg", os.path.join(tower_dir, "Sound.ocg"))
 
 # copy material files into the new directory
 print("copying material files ...")
-shutil.copytree("Material.ocg", tower_dir + "/Material.ocg")
+shutil.copytree("Material.ocg", os.path.join(tower_dir, "Material.ocg"))
 
 # copy tower objects into the new directory
 print("copying tower objects ...")
-shutil.copytree("TowerObjects.ocd", tower_dir + "/TowerObjects.ocd")
+shutil.copytree("TowerObjects.ocd", os.path.join(tower_dir, "TowerObjects.ocd"))
 
 # copy empty scenario section into the new directory
 print("copying empty scenario section ...")
-shutil.copytree("SectEmpty.ocg", tower_dir + "/SectEmpty.ocg")
+shutil.copytree("SectEmpty.ocg", os.path.join(tower_dir, "SectEmpty.ocg"))
 
 # loop over all rooms and copy sections and room object
 print("===========================================")
@@ -199,15 +199,15 @@ for room_dir in os.listdir("."):
 		copy_room(room_dir, tower_dir)
 
 # copy stringtables of rooms into scenario one (temporary fix)
-strtbl_us = open(tower_dir + "/StringTblUS.txt", "a")
-strtbl_de = open(tower_dir + "/StringTblDE.txt", "a")
+strtbl_us = open(os.path.join(tower_dir, "StringTblUS.txt"), "a")
+strtbl_de = open(os.path.join(tower_dir, "StringTblDE.txt"), "a")
 for sect_dir in os.listdir(tower_dir):
 	if fnmatch.fnmatch(sect_dir, "Sect*.ocg"):
-		if os.path.isfile(tower_dir + "/" +  sect_dir + "/StringTblUS.txt"):
-			f = open(tower_dir + "/" +  sect_dir + "/StringTblUS.txt", "r")
+		if os.path.isfile(os.path.join(tower_dir, sect_dir, "StringTblUS.txt")):
+			f = open(os.path.join(tower_dir, sect_dir, "StringTblUS.txt"), "r")
 			strtbl_us.write("\n" + f.read())
-		if os.path.isfile(tower_dir + "/" +  sect_dir + "/StringTblDE.txt"):
-			f = open(tower_dir + "/" +  sect_dir + "/StringTblDE.txt", "r")
+		if os.path.isfile(os.path.join(tower_dir, sect_dir, "StringTblDE.txt")):
+			f = open(os.path.join(tower_dir, sect_dir, "StringTblDE.txt"), "r")
 			strtbl_de.write("\n" + f.read())
 strtbl_us.close()
 strtbl_de.close()
@@ -225,13 +225,13 @@ if args.pack:
 if args.template:
 	print("===========================================")
 	print("create room template ...")
-	template_dir = "../Template.ocg"
+	template_dir = os.path.join("..", "Template.ocg")
 	if not os.path.isdir(template_dir):
 		os.makedirs(template_dir)
-	if os.path.isdir(template_dir + "/RoomTemplate.ocs"):
-		shutil.rmtree(template_dir + "/RoomTemplate.ocs")
-	shutil.copytree("Template.ocg/RoomTemplate.ocs", template_dir + "/RoomTemplate.ocs")
-	shutil.copytree("RoomTemplate.ocs/RoomTemplate.ocd", template_dir + "/RoomTemplate.ocs/RoomTemplate.ocd")
+	if os.path.isdir(os.path.join(template_dir, "RoomTemplate.ocs")):
+		shutil.rmtree(os.path.join(template_dir, "RoomTemplate.ocs"))
+	shutil.copytree(os.path.join("Template.ocg", "RoomTemplate.ocs"), os.path.join(template_dir, "RoomTemplate.ocs"))
+	shutil.copytree(os.path.join("RoomTemplate.ocs", "RoomTemplate.ocd"), os.path.join(template_dir, "RoomTemplate.ocs", "RoomTemplate.ocd"))
 
 # if verbose option create the list of rooms sorted according to difficulty
 if args.verbose:

--- a/scripts/create_tower.py
+++ b/scripts/create_tower.py
@@ -18,7 +18,7 @@ def copy_room(room_dir, tower_dir):
 	# get room name
 	room_name = room_dir.split(".")[0][4:]
 	print("copying room %s ..." % room_name)
-	
+
 	# check against double room names
 	if room_name in room_names:
 		print("ERROR: room name (%s) already used." % room_name)
@@ -53,7 +53,7 @@ def copy_room(room_dir, tower_dir):
 				with open(os.path.join(tower_dir, "Room%s.ocd" % room_name, "Script.c"), "a") as script_file:
 					for line in map_file.readlines():
 						if not re.match("#include *", line):
-							script_file.write(line)	
+							script_file.write(line)
 
 	# check the newly created room, remove if the checks were not satisfied
 	if not check_room(room_name, tower_dir):
@@ -110,7 +110,7 @@ def check_room(room_name, tower_dir):
 		room_ids.append(room_id)
 		room_diffs.append(room_diff)
 		room_authors.append(room_author)
-	
+
 	# print(room settings)
 	if args.verbose and room_ok:
 		print("room properties: id = %s, difficulty = %s" % (room_id, room_diff))
@@ -143,7 +143,7 @@ if not os.path.isfile("Version.txt"):
 	print("ERROR: Version.txt file not found, be sure to run the script from the tower path.")
 	sys.exit(0)
 with open("Version.txt", "r") as content_file:
-    version = content_file.read()
+	version = content_file.read()
 tower_dir = os.path.join("..", "OCTowerV%s.ocs" % version)
 ## TODO: query replacing existing directory
 if os.path.isfile(tower_dir):


### PR DESCRIPTION
This PR updates create_tower.py to make it Python 3 compatible. The primary change here is 
386b44e070a13bd2477ef4955884a9fa2df2f42e, which updates all the `print` statements to use the function syntax (`print("str")` over `print "str"`).

The other committs in this PR clean up the script a bit more; 7d5f7fb843131c521ec37c73e4ad2c296276a938 introduces `os.path.join` instead of hardcoded directory seperators, 346a08500f669ee729a196f8254041068e18e2f4 switches to interpolated strings and 6ef0d6e9f5a7fcb2b954464f7697a2651cdb112c makes the last verbose print statement much more readable. I've also added 4e6ca07260c9b261f8fdd3d7778dbf5cf10d8abd to clean up the indentation.

I've tested the new version and it works fine on Python 2/3.